### PR TITLE
JS ディレクトリーにファイルが１つも無い場合エラーになる問題を修正

### DIFF
--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -53,7 +53,7 @@ const getEntryFiles = (paths) => {
 module.exports = function transpileScript(done) {
   const paths = getPaths(this);
   const entryFiles = getEntryFiles(paths);
-  if (!entryFiles) return done();
+  if (Object.keys(entryFiles).length < 1) return done();
 
   return gulp.src(['./src/**/js/*.js'])
   .pipe(plumber())


### PR DESCRIPTION
# 修正点

条件分岐が必ず false になってしまう状態だったので修正